### PR TITLE
Upgrade Plotly lib to most recent version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ MarkupSafe==1.1.1
 nbformat==4.4.0
 numpy==1.16.4
 pandas==0.24.2
-plotly==4.1.0
+plotly==4.14.3
 pytz==2019.1
 six==1.12.0
 traitlets==4.3.2


### PR DESCRIPTION
So the app was running for me but after I properly installed the requirements with `pip install -r requirements.txt` that installed the _exact_ version of the libraries in that file. In the case of Plotly version 4.1.0 compared to the most recent 4.14.3. It is hard to find documentation for the older versions but likely the `scatter_geo` function changed between versions.

Why this matters is because Heroku also installs the Python dependency libraries using the versions in that file. So you probably have a different version of plotly on your local machine where you test your code and it works, but then fails on Heroku.

If you have it working on your local machine still you should ignore this pull request and instead do:

```bash
rm requirements.txt
pip freeze > requirements.txt
```

(some details [here](https://note.nkmk.me/en/python-pip-install-requirements/))

That will make sure Heroku is using the exact same version of the Python libraries as when you are working and testing it locally.

Hope that helps, it looks cool on my local machine. Get it live!